### PR TITLE
Ignore exceptions from type coercion in value comparison

### DIFF
--- a/src/Avalonia.Xaml.Interactions/Core/DataTriggerBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/DataTriggerBehavior.cs
@@ -75,7 +75,14 @@ public class DataTriggerBehavior : Trigger
             var destinationType = leftOperand.GetType();
             if (value is { })
             {
-                rightOperand = TypeConverterHelper.Convert(value, destinationType);
+                try
+                {
+                    rightOperand = TypeConverterHelper.Convert(value, destinationType);
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
             }
         }
 


### PR DESCRIPTION
It's a simple change to avoid exceptions getting thrown from coercion of complex types from string back to the object to completely break the comparison. I have the feeling that this method needs a bit more work, as calling ToString() and then converting it back into a type can fail for many types, even the less complex ones.