### PR TITLE
Add IsEnabled property to InvokeCommandAction

### DIFF
--- a/src/Avalonia.Xaml.Interactions/Core/InvokeCommandAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/InvokeCommandAction.cs
@@ -10,6 +10,12 @@ namespace Avalonia.Xaml.Interactions.Core;
 public class InvokeCommandAction : AvaloniaObject, IAction
 {
     /// <summary>
+    /// Identifies the <seealso cref="IsEnabled"/> avalonia property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsEnabledProperty =
+        AvaloniaProperty.Register<InvokeCommandAction, bool>(nameof(IsEnabled), defaultValue: true);
+
+    /// <summary>
     /// Identifies the <seealso cref="Command"/> avalonia property.
     /// </summary>
     public static readonly StyledProperty<ICommand?> CommandProperty =
@@ -39,6 +45,16 @@ public class InvokeCommandAction : AvaloniaObject, IAction
     /// <remarks>The string.Empty used for default value string means the invariant culture.</remarks>
     public static readonly StyledProperty<string?> InputConverterLanguageProperty =
         AvaloniaProperty.Register<InvokeCommandAction, string?>(nameof(InputConverterLanguage), string.Empty);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this instance is enabled.
+    /// </summary>
+    /// <value><c>true</c> if this instance is enabled; otherwise, <c>false</c>.</value>
+    public bool IsEnabled
+    {
+        get => GetValue(IsEnabledProperty);
+        set => SetValue(IsEnabledProperty, value);
+    }
 
     /// <summary>
     /// Gets or sets the command this action should invoke. This is a avalonia property.
@@ -105,7 +121,7 @@ public class InvokeCommandAction : AvaloniaObject, IAction
     /// <returns>True if the command is successfully executed; else false.</returns>
     public virtual object Execute(object? sender, object? parameter)
     {
-        if (Command is null)
+        if (IsEnabled != true || Command is null)
         {
             return false;
         }
@@ -121,7 +137,7 @@ public class InvokeCommandAction : AvaloniaObject, IAction
                 parameter,
                 typeof(object),
                 InputConverterParameter,
-                InputConverterLanguage is { } ? 
+                InputConverterLanguage is { } ?
                     new System.Globalization.CultureInfo(InputConverterLanguage)
                     : System.Globalization.CultureInfo.CurrentCulture);
         }


### PR DESCRIPTION
Added a new boolean property, IsEnabled, with a default value of true to the InvokeCommandAction. The Execute method now checks this property, and if it is set to false, the command is not executed.