### PR TITLE
Fixed FocusBehavior

### DIFF
--- a/src/Avalonia.Xaml.Interactions.Custom/FocusBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/FocusBehavior.cs
@@ -31,20 +31,27 @@ public class FocusBehavior : DisposingBehavior<Control>
     /// <param name="disposables"></param>
     protected override void OnAttached(CompositeDisposable disposables)
     {
-        base.OnAttached();
-
         if (AssociatedObject is not null)
         {
-            AssociatedObject.AttachedToLogicalTree += (_, _) =>
-                disposables.Add(this.GetObservable(IsFocusedProperty)
-                    .Subscribe(new AnonymousObserver<bool>(
-                        focused =>
+            disposables.Add(AssociatedObject.GetObservable(Avalonia.Input.InputElement.IsFocusedProperty)
+                .Subscribe(new AnonymousObserver<bool>(
+                    focused =>
+                    {
+                        if (!focused)
                         {
-                            if (focused)
-                            {
-                                AssociatedObject.Focus();
-                            }
-                        })));
+                            IsFocused = false;
+                        }
+                    })));
+
+            disposables.Add(this.GetObservable(IsFocusedProperty)
+                .Subscribe(new AnonymousObserver<bool>(
+                    focused =>
+                    {
+                        if (focused)
+                        {
+                            AssociatedObject.Focus();
+                        }
+                    })));
         }
     }
 }


### PR DESCRIPTION
1. StackoverflowException - removed base.OnAttached()
2. No AttachedtoLogicalTree event, control already attached - removed event connection
3. IsFocused don't set on false automatically, added connection to associated object IsFocused changed to set behavior IsFocused = false