### PR TITLE
Add properties to Behavior to enable Bindings to AssociatedObject

### DIFF
--- a/src/Avalonia.Xaml.Interactivity/Avalonia.Xaml.Interactivity.csproj
+++ b/src/Avalonia.Xaml.Interactivity/Avalonia.Xaml.Interactivity.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
   <Import Project="..\..\build\SignAssembly.props" />


### PR DESCRIPTION
This uses new properties to enable clients Bind to the AssociatedObject.